### PR TITLE
Remove the first post which is an group introduction

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -11,7 +11,7 @@ layout: null
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
-    {% for post in site.posts limit:10 %}
+    {% for post in site.posts offset:1 limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>


### PR DESCRIPTION
The first post is an group introduction page, it should not be added to feed.xml
