### PR TITLE
JKM-4 add support for disqus comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,5 +26,8 @@ more_vert:
     name: Cool Option 3
     link: www.myawesomelink.com
 
+disqus: true
+disqus_shortname: 'gdgmanagua'
+
 # Build settings
 markdown: kramdown

--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,0 +1,14 @@
+<section class="disqus">
+    <div id="disqus_thread"></div>
+    <script type="text/javascript">
+        var disqus_shortname = '{{ site.disqus_shortname }}';
+        var disqus_developer = 0; // developer mode is on
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+</section>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,6 +13,13 @@ layout: default
       <article class="post-content">
         <p>{{ content }}</p>
       </article>
+      <!-- Disqus comments -->
+      {% if site.disqus %}
+      <div>
+        <h3>Comments</h3>
+        {% include disqus.html %}
+      </div>
+      {% endif %}
     </div>
   </div>
 </main>


### PR DESCRIPTION
This PR! add support for disqus comments in the post layout.

Only set your disqus short name and set it to true, and now you will be able to use disqus in the site.
