### PR TITLE
JKM-31 Fix share button in highlight post #31

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@ layout: default
         </div>
       </div>
 
-      <button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon" id="btn-high">
+      <button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon" id="btn-high-{{ post.id }}">
         <i class="material-icons">more_vert</i>
       </button>
-      <ul class="mdl-menu mdl-js-menu mdl-menu--bottom-right" for="btn-high">
+      <ul class="mdl-menu mdl-js-menu mdl-menu--bottom-right" for="btn-high-{{ post.id }}">
         <li><a href="https://www.facebook.com/dialog/share?app_id={app_id}&display=page&href={{ post.url | prepend: site.baseurl }}&redirect_uri={{ site.baseurl }}" class="mdl-menu__item">Facebook</a></li>
         <li><a href="https://twitter.com/share?url={{ post.url | prepend: site.baseurl }}&text={{ post.title }}&via={{ site.twitter_username }}" class="mdl-menu__item">Twitter</a></li>
         <li><a href="https://plus.google.com/share?url={{ post.url | prepend: site.baseurl }}" class="mdl-menu__item">Google+</a></li>


### PR DESCRIPTION
Caused by duplicated identifiers in button and item share list. Add the post id to differentiate the post
