### PR TITLE
Explicitly define height as auto

### DIFF
--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -34,6 +34,7 @@
   .post-content {
     img {
       width: 100%;
+      height: auto;
     }
   }
 }


### PR DESCRIPTION
While using only width at 100% it stretches all imgs in the post to width
of parent div.  But doesn't maintain aspect ratio.  This corrects this
issue.  Regardless, setting width to 100% makes img tags width/height be
ignored.
